### PR TITLE
Send Transcriptor emails to dedicated mail alias

### DIFF
--- a/bbc-newslabs-footer.js
+++ b/bbc-newslabs-footer.js
@@ -161,6 +161,12 @@ xml:space="preserve">
                     'mailto:newslabs-development@lists.forge.bbc.co.uk?subject='
                     + encodeURI(newvalue + " feedback")
             }
+            else if (name=='Transcriptor')
+            {
+                this.shadowRoot.getElementById('mailto').href=
+                    'mailto:transcriptor@bbcnewslabs.co.uk?subject='
+                    + encodeURI(newvalue + " feedback")
+            }
         }
     }
 

--- a/bbc-newslabs-footer.js
+++ b/bbc-newslabs-footer.js
@@ -142,7 +142,7 @@ xml:space="preserve">
 
     &nbsp; | &nbsp;
 
-    <a title="Send us an email" email id="mailto" href="mailto:newslabs-development@lists.forge.bbc.co.uk">
+    <a title="Send us an email" email id="mailto" href="mailto:${this.email + this.subject}">
     Submit feedback
     <svg height="20px" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="envelope" class="svg-inline--fa fa-envelope fa-w-16 " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M502.3 190.8c3.9-3.1 9.7-.2 9.7 4.7V400c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V195.6c0-5 5.7-7.8 9.7-4.7 22.4 17.4 52.1 39.5 154.1 113.6 21.1 15.4 56.7 47.8 92.2 47.6 35.7.3 72-32.8 92.3-47.6 102-74.1 131.6-96.3 154-113.7zM256 320c23.2.4 56.6-29.2 73.4-41.4 132.7-96.3 142.8-104.7 173.4-128.7 5.8-4.5 9.2-11.5 9.2-18.9v-19c0-26.5-21.5-48-48-48H48C21.5 64 0 85.5 0 112v19c0 7.4 3.4 14.3 9.2 18.9 30.6 23.9 40.7 32.4 173.4 128.7 16.8 12.2 50.2 41.8 73.4 41.4z"></path></svg></a>
 
@@ -154,26 +154,37 @@ xml:space="preserve">
     }
 
     attributeChangedCallback(name, oldvalue, newvalue) {
-        if (oldvalue!=newvalue) {
-            if (name=='app')
-            {
-                this.shadowRoot.getElementById('mailto').href=
-                    'mailto:newslabs-development@lists.forge.bbc.co.uk?subject='
-                    + encodeURI(newvalue + " feedback")
-            }
-            else if (name=='Transcriptor')
-            {
-                this.shadowRoot.getElementById('mailto').href=
-                    'mailto:transcriptor@bbcnewslabs.co.uk?subject='
-                    + encodeURI(newvalue + " feedback")
+        if (oldvalue != newvalue) {
+            if (name == 'app' || name == 'email') {
+                this.shadowRoot.getElementById('mailto').href = 'mailto:' + this.email + this.subject
             }
         }
     }
 
-    get app() { return this.getAttribute('app') }
-    set app(v) { this.setAttribute('app', v) }
+    get email() {
+        return this.hasAttribute('email') && this.getAttribute('email').trim() || "newslabs-development@lists.forge.bbc.co.uk"
+    }
+    set email(v) {
+        this.setAttribute('email', v.trim())
+    }
 
-    static get observedAttributes() { return [
-        'app',
-    ]}
+    get app() {
+        return this.hasAttribute('app') && this.getAttribute('app').trim() || ""
+    }
+    set app(v) {
+        this.setAttribute('app', v.trim())
+    }
+
+    get subject() {
+        let page = "[" + location.origin + location.pathname + "]"
+        if (this.app.length == 0) return "?subject=" + encodeURI(page)
+        return "?subject=" + encodeURI(this.app + " feedback " + page)
+    }
+
+    static get observedAttributes() {
+        return[
+            'app',
+            'email',
+        ]
+    }
 })

--- a/bbc-newslabs-footer.js
+++ b/bbc-newslabs-footer.js
@@ -169,14 +169,17 @@ xml:space="preserve">
     }
 
     get app() {
-        return this.hasAttribute('app') && this.getAttribute('app').trim() || ""
+        let app, meta
+        if ((app=this.getAttribute('app'))) return app
+        if ((meta=document.querySelector('meta[name=application-name]')) && (app=meta.getAttribute('content'))) return app
+        return ""
     }
     set app(v) {
         this.setAttribute('app', v.trim())
     }
 
     get subject() {
-        let page = "[" + location.origin + location.pathname + "]"
+        const page = "[" + location.origin + location.pathname + "]"
         if (this.app.length == 0) return "?subject=" + encodeURI(page)
         return "?subject=" + encodeURI(this.app + " feedback " + page)
     }


### PR DESCRIPTION
Proposed change to newslabs-footer to direct Transcriptor app feedback directly to dedicated transcriptor mail alias instead of generic newslabs-development mail alias